### PR TITLE
libudev and alsaLib were renamed on NixOS

### DIFF
--- a/client/src/nix.rs
+++ b/client/src/nix.rs
@@ -6,7 +6,7 @@ const PATCH_DRV: &str = r#"
 let
   runtimeLibs =
     with pkgs;
-    ([ libGL libxkbcommon libudev alsaLib vulkan-loader vulkan-extension-layer stdenv.cc.cc.lib ]
+    ([ libGL libxkbcommon udev alsa-lib vulkan-loader vulkan-extension-layer stdenv.cc.cc.lib ]
             ++ (with xorg; [ libxcb libX11 libXcursor libXrandr libXi ]));
 in
 pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
This would break the patching as accessing `udev` by its old `libudev` alias now throws an error.

The `udev` and `alsa-lib` names are both usable in 21.11 (the most recent, supported version of NixOS).